### PR TITLE
Fix escapeSingleQuotes to replace all

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const toIdentifier = require('to-js-identifier')
 const combine = require('combine-arrays')
 
 const sortByDirectoryDepth = require('./sort-by-directory-depth')
-const escapeSingleQuotes = str => str.replace(`'`, () => `\\'`)
+const escapeSingleQuotes = str => str.replace(/'/g, `\\'`)
 
 module.exports = function globModuleFile({
 	format = 'cjs',


### PR DESCRIPTION
```js
const escapeSingleQuotes1 = str => str.replace(`'`, () => `\\'`)
const escapeSingleQuotes2 = str => str.replace(/'/g, `\\'`)
escapeSingleQuotes1("I'm havin' fun") // => "I\'m havin' fun" // BEFORE
escapeSingleQuotes2("I'm havin' fun") // => "I\'m havin\' fun" // AFTER
```